### PR TITLE
Update cors policy to allow connections from Azure Portal

### DIFF
--- a/NetStackBeautifier.WebAPI/Program.cs
+++ b/NetStackBeautifier.WebAPI/Program.cs
@@ -21,7 +21,8 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddCors(opt => opt.AddDefaultPolicy(policy =>
 {
-    policy.WithOrigins("https://stack.codewithsaar.net")
+    string[] origins = {"https://stack.codewithsaar.net", "https://*.portal.azure.com", "https://ms.portal.azure.com", "https://portal.azure.com" };
+    policy.WithOrigins(origins)
     .AllowAnyHeader()
     .AllowAnyMethod();
 }));

--- a/NetStackBeautifier.WebAPI/Program.cs
+++ b/NetStackBeautifier.WebAPI/Program.cs
@@ -21,7 +21,12 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddCors(opt => opt.AddDefaultPolicy(policy =>
 {
-    string[] origins = {"https://stack.codewithsaar.net", "https://*.portal.azure.com", "https://ms.portal.azure.com", "https://portal.azure.com" };
+    string[] origins = {
+        "https://stack.codewithsaar.net",
+        "https://ms.portal.azure.com",
+        "https://portal.azure.com"
+    };
+
     policy.WithOrigins(origins)
     .AllowAnyHeader()
     .AllowAnyMethod();


### PR DESCRIPTION
Quick update to accept requests from Azure portal. Wildcards don't seem to work for secondary subdomains but if we wanted we could accept `*.azure.com`.