### PR TITLE
Add pre filters and pre filter runner in base class to tag lines with retained information

### DIFF
--- a/NetStackBeautifier.Services/BeautifierBase.cs
+++ b/NetStackBeautifier.Services/BeautifierBase.cs
@@ -10,25 +10,32 @@ namespace NetStackBeautifier.Services
         private readonly LineBreaker _lineBreaker;
         private readonly IEnumerable<ILineBeautifier<T>> _lineBeautifiers;
         private readonly IEnumerable<IFrameFilter<T>> _filters;
+         private readonly IEnumerable<IPreFilter<T>> _preFilters;
 
         public BeautifierBase(
             LineBreaker lineBreaker,
             IEnumerable<ILineBeautifier<T>> lineBeautifiers,
-            IEnumerable<IFrameFilter<T>> filters)
+            IEnumerable<IFrameFilter<T>> filters,
+            IEnumerable<IPreFilter<T>> preFilters)
         {
             _lineBreaker = lineBreaker ?? throw new ArgumentNullException(nameof(lineBreaker));
             _lineBeautifiers = lineBeautifiers ?? throw new ArgumentNullException(nameof(lineBeautifiers));
             _filters = filters ?? throw new ArgumentNullException(nameof(filters));
+            _preFilters = preFilters ?? throw new ArgumentNullException(nameof(filters));
         }
 
         public async IAsyncEnumerable<IFrameLine> BeautifyAsync(
             string input,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
+            int lineIndex = 0;
             foreach (string line in _lineBreaker.BreakIntoLines(input))
             {
                 // TODO: Revisit the logic to form hierarchy.
                 IFrameLine newItem = CreateFrameItem(line);
+                RunPreFilters(newItem, line, lineIndex);
+                lineIndex += 1;
+                
                 yield return await BeautifyAsync(newItem, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -49,6 +56,14 @@ namespace NetStackBeautifier.Services
                 filter.Filter(input);
             }
             return input;
+        }
+
+        private void RunPreFilters(IFrameLine input, string line, int index)
+        {
+            foreach(IPreFilter<T> filter in _preFilters)
+            {
+                filter.Filter(input, line, index);
+            }
         }
 
         protected abstract IFrameLine CreateFrameItem(string line);

--- a/NetStackBeautifier.Services/BeautifierBase.cs
+++ b/NetStackBeautifier.Services/BeautifierBase.cs
@@ -10,7 +10,7 @@ namespace NetStackBeautifier.Services
         private readonly LineBreaker _lineBreaker;
         private readonly IEnumerable<ILineBeautifier<T>> _lineBeautifiers;
         private readonly IEnumerable<IFrameFilter<T>> _filters;
-         private readonly IEnumerable<IPreFilter<T>> _preFilters;
+        private readonly IEnumerable<IPreFilter<T>> _preFilters;
 
         public BeautifierBase(
             LineBreaker lineBreaker,
@@ -28,14 +28,13 @@ namespace NetStackBeautifier.Services
             string input,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            int lineIndex = 0;
-            foreach (string line in _lineBreaker.BreakIntoLines(input))
+            foreach (var lineInfo in _lineBreaker.BreakIntoLines(input).Select((value, i) => (i, value)))
             {
+                (int index, string line) = lineInfo;
                 // TODO: Revisit the logic to form hierarchy.
                 IFrameLine newItem = CreateFrameItem(line);
-                RunPreFilters(newItem, line, lineIndex);
-                lineIndex += 1;
-                
+                RunPreFilters(newItem, line, index);
+
                 yield return await BeautifyAsync(newItem, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -60,7 +59,7 @@ namespace NetStackBeautifier.Services
 
         private void RunPreFilters(IFrameLine input, string line, int index)
         {
-            foreach(IPreFilter<T> filter in _preFilters)
+            foreach (IPreFilter<T> filter in _preFilters)
             {
                 filter.Filter(input, line, index);
             }

--- a/NetStackBeautifier.Services/Filters/IPreFilter.cs
+++ b/NetStackBeautifier.Services/Filters/IPreFilter.cs
@@ -1,0 +1,9 @@
+namespace NetStackBeautifier.Services.Filters;
+public interface IPreFilter<T>
+    where T: IBeautifier
+{
+    /// <summary>
+    /// Adding tags to an IFrameLine with pre-processed information
+    /// </summary>
+    void Filter(IFrameLine frameline, string line, int index);
+}

--- a/NetStackBeautifier.Services/Filters/RetainedFilter.cs
+++ b/NetStackBeautifier.Services/Filters/RetainedFilter.cs
@@ -1,0 +1,15 @@
+namespace NetStackBeautifier.Services.Filters;
+
+internal class RetainedFilter<T> : IPreFilter<T>
+    where T : IBeautifier
+{
+    public void Filter(IFrameLine frameLine, string fullLine, int startingIndex)
+    {
+        if (frameLine == null)
+        {
+            return;
+        }
+        frameLine.Tags.TryAdd("FullLine", fullLine);
+        frameLine.Tags.Add("StartingIndex", startingIndex.ToString());
+    }
+}

--- a/NetStackBeautifier.Services/Parsers/AIProfilerStackBeautifier.cs
+++ b/NetStackBeautifier.Services/Parsers/AIProfilerStackBeautifier.cs
@@ -41,8 +41,9 @@ internal class AIProfilerStackBeautifier : BeautifierBase<AIProfilerStackBeautif
         LineBreaker lineBreaker,
         IEnumerable<ILineBeautifier<AIProfilerStackBeautifier>> lineBeautifiers,
         IEnumerable<IFrameFilter<AIProfilerStackBeautifier>> filters,
+        IEnumerable<IPreFilter<AIProfilerStackBeautifier>> preFilters,
         FrameClassNameFactory frameClassNameFactory)
-        : base(lineBreaker, lineBeautifiers, filters)
+        : base(lineBreaker, lineBeautifiers, filters, preFilters)
     {
         _lineBreaker = lineBreaker ?? throw new ArgumentNullException(nameof(lineBreaker));
         _frameClassNameFactory = frameClassNameFactory ?? throw new ArgumentNullException(nameof(frameClassNameFactory));

--- a/NetStackBeautifier.Services/Parsers/AzureProfilerStackBeautifier.cs
+++ b/NetStackBeautifier.Services/Parsers/AzureProfilerStackBeautifier.cs
@@ -22,8 +22,9 @@ internal class AzureProfilerStackBeautifier : BeautifierBase<AzureProfilerStackB
         LineBreaker lineBreaker,
         IEnumerable<ILineBeautifier<AzureProfilerStackBeautifier>> lineBeautifiers,
         IEnumerable<IFrameFilter<AzureProfilerStackBeautifier>> filters,
+        IEnumerable<IPreFilter<AzureProfilerStackBeautifier>> preFilters,
         FrameClassNameFactory frameClassNameFactory
-        ) : base(lineBreaker, lineBeautifiers, filters)
+        ) : base(lineBreaker, lineBeautifiers, filters, preFilters)
     {
         _lineBreaker = lineBreaker ?? throw new ArgumentNullException(nameof(lineBreaker));
         _frameClassNameFactory = frameClassNameFactory ?? throw new ArgumentNullException(nameof(frameClassNameFactory));

--- a/NetStackBeautifier.Services/Parsers/SimpleExceptionStackBeautifier.cs
+++ b/NetStackBeautifier.Services/Parsers/SimpleExceptionStackBeautifier.cs
@@ -54,8 +54,9 @@ internal class SimpleExceptionStackBeautifier : BeautifierBase<SimpleExceptionSt
         LineBreaker lineBreaker,
         IEnumerable<ILineBeautifier<SimpleExceptionStackBeautifier>> lineBeautifiers,
         IEnumerable<IFrameFilter<SimpleExceptionStackBeautifier>> filters,
+        IEnumerable<IPreFilter<SimpleExceptionStackBeautifier>> preFilters,
         FrameClassNameFactory frameClassNameFactory)
-            : base(lineBreaker, lineBeautifiers, filters)
+            : base(lineBreaker, lineBeautifiers, filters, preFilters)
     {
         _frameClassNameFactory = frameClassNameFactory ?? throw new ArgumentNullException(nameof(frameClassNameFactory));
     }

--- a/NetStackBeautifier.Services/Register.cs
+++ b/NetStackBeautifier.Services/Register.cs
@@ -27,6 +27,7 @@ namespace NetStackBeautifier.Services
             services.TryAddScoped<IBeautifierService, BeautifierService>();
 
             services.TryAddScoped(typeof(IFrameFilter<>), typeof(NoiseFilter<>));
+            services.TryAddScoped(typeof(IPreFilter<>), typeof(RetainedFilter<>));
             services.TryAddScoped<IFrameFilter<SimpleExceptionStackBeautifier>, DICannotInstantiateTagger>();
             return services;
         }


### PR DESCRIPTION
@xiaomi7732 Is this roughly what you had in mind? Created a separate pre-filters interface that accepts "request level" information, just like the current filter system you can inherit from the interface and inject pre filters as needed. Then a pre filters runner defined in our BeautifierBase iterates over all the registered pre-filters prior to parsing. 