### PR TITLE
Create raw request object to store and work with request level information

### DIFF
--- a/src/NetStackBeautifier.Core/Models/RawRequest.cs
+++ b/src/NetStackBeautifier.Core/Models/RawRequest.cs
@@ -1,0 +1,13 @@
+namespace NetStackBeautifier.Services
+{
+    public class RawRequest
+    {
+        public RawRequest(string value, int index)
+        {
+            Value = value;
+            Index = index;
+        }
+        public int Index { get; private set; }
+        public string Value { get; private set; }
+    }
+}

--- a/src/NetStackBeautifier.Core/Models/RawRequest.cs
+++ b/src/NetStackBeautifier.Core/Models/RawRequest.cs
@@ -7,7 +7,7 @@ namespace NetStackBeautifier.Services
             Value = value;
             Index = index;
         }
-        public int Index { get; private set; }
-        public string Value { get; private set; }
+        public int Index { get; }
+        public string Value { get; }
     }
 }

--- a/src/NetStackBeautifier.Services/BeautifierBase.cs
+++ b/src/NetStackBeautifier.Services/BeautifierBase.cs
@@ -28,7 +28,7 @@ namespace NetStackBeautifier.Services
             string input,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            foreach (var rawRequest in _lineBreaker.BreakIntoLines(input).Select((value, i) => new RawRequest(value, i)))
+            foreach (RawRequest rawRequest in _lineBreaker.BreakIntoLines(input).Select((value, i) => new RawRequest(value, i)))
             {
                 // TODO: Revisit the logic to form hierarchy.
                 IFrameLine newItem = CreateFrameItem(rawRequest.Value);

--- a/src/NetStackBeautifier.Services/BeautifierBase.cs
+++ b/src/NetStackBeautifier.Services/BeautifierBase.cs
@@ -28,12 +28,11 @@ namespace NetStackBeautifier.Services
             string input,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            foreach (var lineInfo in _lineBreaker.BreakIntoLines(input).Select((value, i) => (i, value)))
+            foreach (var rawRequest in _lineBreaker.BreakIntoLines(input).Select((value, i) => new RawRequest(value, i)))
             {
-                (int index, string line) = lineInfo;
                 // TODO: Revisit the logic to form hierarchy.
-                IFrameLine newItem = CreateFrameItem(line);
-                RunPreFilters(newItem, line, index);
+                IFrameLine newItem = CreateFrameItem(rawRequest.Value);
+                RunPreFilters(newItem, rawRequest);
 
                 yield return await BeautifyAsync(newItem, cancellationToken).ConfigureAwait(false);
             }
@@ -57,11 +56,11 @@ namespace NetStackBeautifier.Services
             return input;
         }
 
-        private void RunPreFilters(IFrameLine input, string line, int index)
+        private void RunPreFilters(IFrameLine input, RawRequest rawRequest)
         {
             foreach (IPreFilter<T> filter in _preFilters)
             {
-                filter.Filter(input, line, index);
+                filter.Filter(input, rawRequest);
             }
         }
 

--- a/src/NetStackBeautifier.Services/Filters/IPreFilter.cs
+++ b/src/NetStackBeautifier.Services/Filters/IPreFilter.cs
@@ -5,5 +5,5 @@ public interface IPreFilter<T>
     /// <summary>
     /// Adding tags to an IFrameLine with pre-processed information
     /// </summary>
-    void Filter(IFrameLine frameline, string line, int index);
+    void Filter(IFrameLine frameline, RawRequest rawRequest);
 }

--- a/src/NetStackBeautifier.Services/Filters/RetainedFilter.cs
+++ b/src/NetStackBeautifier.Services/Filters/RetainedFilter.cs
@@ -5,7 +5,7 @@ internal class RetainedFilter<T> : IPreFilter<T>
 {
     public void Filter(IFrameLine frameLine, RawRequest rawRequest)
     {
-        if (frameLine == null || rawRequest == null)
+        if (frameLine is null || rawRequest is null)
         {
             return;
         }

--- a/src/NetStackBeautifier.Services/Filters/RetainedFilter.cs
+++ b/src/NetStackBeautifier.Services/Filters/RetainedFilter.cs
@@ -3,13 +3,13 @@ namespace NetStackBeautifier.Services.Filters;
 internal class RetainedFilter<T> : IPreFilter<T>
     where T : IBeautifier
 {
-    public void Filter(IFrameLine frameLine, string fullLine, int startingIndex)
+    public void Filter(IFrameLine frameLine, RawRequest rawRequest)
     {
-        if (frameLine == null)
+        if (frameLine == null || rawRequest == null)
         {
             return;
         }
-        frameLine.Tags.TryAdd("fullLine", fullLine);
-        frameLine.Tags.Add("startingIndex", startingIndex.ToString());
+        frameLine.Tags.TryAdd("fullLine", rawRequest.Value.Trim());
+        frameLine.Tags.Add("startingIndex", rawRequest.Index.ToString());
     }
 }


### PR DESCRIPTION
This adds a `RawRequest` object. Rather than passing around line and index we are storing them in this object which will be used for request level data, and data received prior to parsing our line. This fits better in our data model, it gives us a nice default object piggy backing off of our Select overload. Going forward the pattern when working with information received prior to creating our `IFrameLine` is the data should be stored in `RawRequest` and passed down as such. This is also currently a dependency of any pre-filters that will be built. 

Haven't given this too much thought yet but if we wanted to decouple pre-filters from `RawRequest` so it's up to the implemented class to define what, if any, data it needs we could do something like register RawRequst as a scoped item and update the values in our select overload. I don't like the idea of having that scoped state and letting those values get mutated at any point in our lifecycle though because it takes a lot of the trust away. Something that might be better is registering a list in RawRequests that we can push up to as we receive our lines `_lineBreaker.BreakIntoLines(input).Select((value, i) => RawRequest.PushLine(value, i)`. At that point we know where the most recent raw request is if we need to access that and a nice side affect is we'd be able to do things like look behinds on previous lines if need be. 

In that case our IPreFilter would be identical to IFilter so maybe even just add a "type" property for the inheriting class to implement that takes a FilterType (or FilterLifecycle maybe) enum of `Pre` or `Default`. Then it can be left up to a filter runner function to take in the LifeCycle value and run the relevant filters as needed. This isn't super necessary however I thought it could lead to a pattern where we have a single Filter base class that is inherited by all of our filters where we can keep shared logic, such as a static filter runner, and the process for adding additional LifeCycles for a filter is just a matter of adding to the enum rather than creating a new interface and registering it.