### PR TITLE
Fix premature return

### DIFF
--- a/src/NetStackBeautifier.Services/Parsers/AIProfilerStackBeautifier.cs
+++ b/src/NetStackBeautifier.Services/Parsers/AIProfilerStackBeautifier.cs
@@ -71,7 +71,7 @@ internal class AIProfilerStackBeautifier : BeautifierBase<AIProfilerStackBeautif
 
             if (!_canBeautifyMatcher.Match(line).Success)
             {
-                return false;
+                break;
             }
         }
         // When every line passes check for canBeautify matcher, it is good to in shape.


### PR DESCRIPTION
The dev backend is currently returning an empty array for most of the stacks on the Portal. This is due to a premature `return` that should be a `break;` returning false for any stack with an unparsable line. 

Example breaking stack for testing:

```code
Type System.String
mscorlib.ni!System.String.InternalSubString(Int32, Int32)
mscorlib.ni!System.String.Substring(Int32, Int32)
diagservice!DiagService.Runners.StringOperationRunner.Run(int32,value class DiagService.OperationEnum)
diagservice!DiagService.Controllers.MemoryController.StringSubstring(int32)
anonymously hosted dynamicmethods assembly!dynamicClass.lambda_method(pMT: 6FEF0FF8,class System.Object,class System.Object[])
system.web.http!System.Web.Http.Controllers.ReflectedHttpActionDescriptor+ActionExecutor.Execute(class System.Object,class System.Object[])
system.web.http!System.Web.Http.Controllers.ApiControllerActionInvoker+<InvokeActionAsyncCore>d__1.MoveNext()
mscorlib!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&)
```