### PR TITLE
Add src to launch and task project paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/NetStackBeautifier.WebAPI/bin/Debug/net6.0/NetStackBeautifier.WebAPI.dll",
+            "program": "${workspaceFolder}/src/NetStackBeautifier.WebAPI/bin/Debug/net6.0/NetStackBeautifier.WebAPI.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/NetStackBeautifier.WebAPI",
+            "cwd": "${workspaceFolder}/src/NetStackBeautifier.WebAPI",
             "stopAtEntry": false,
             // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
             "serverReadyAction": {
@@ -23,7 +23,7 @@
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
             "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
+                "/Views": "${workspaceFolder}/src/Views"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj",
+                "${workspaceFolder}/src/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj",
+                "${workspaceFolder}/src/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,7 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj"
+                "${workspaceFolder}/src/NetStackBeautifier.WebAPI/NetStackBeautifier.WebAPI.csproj"
             ],
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
Currently debugging in vscode is broken because the paths to the csproj files are missing the src directory. 