### PR TITLE
Add a pre styled attribute to html content

### DIFF
--- a/src/NetStackBeautifier.Services/Renders/HtmlRender.cs
+++ b/src/NetStackBeautifier.Services/Renders/HtmlRender.cs
@@ -42,35 +42,6 @@ public class HtmlRender : IRender<string>
         font-size: 14px;
         line-height: 1.5em;
     }
-
-    .description-text {
-    }
-
-    .frame-class-name {
-        color: #996800;
-    }
-
-    .frame-method-name {
-        font-weight: bold;
-        color: #2271B1;
-    }
-
-    .frame-parameter-list {
-        color: #362400;
-    }
-
-    .frame-file-path {
-        color: #336B87;
-    }
-
-    .frame-file-line {
-        color: #D63638;
-    }
-
-    .frame-parameter-type {
-        color: #043959 ;
-        font-weight: bold;
-    }
 </style>");
             }
             finally
@@ -95,6 +66,4 @@ public class HtmlRender : IRender<string>
 
         return htmlBuilder.ToString();
     }
-
-
 }

--- a/src/NetStackBeautifier.Services/Renders/RenderOptions.cs
+++ b/src/NetStackBeautifier.Services/Renders/RenderOptions.cs
@@ -3,4 +3,5 @@ namespace NetStackBeautifier.Services.Renders;
 public class RenderOptions
 {
     public RenderMode Mode { get; set; } = RenderMode.Simple;
+    public bool PreStyled { get; set; } = false;
 }

--- a/src/NetStackBeautifier.WebAPI/Controllers/HtmlContentController.cs
+++ b/src/NetStackBeautifier.WebAPI/Controllers/HtmlContentController.cs
@@ -19,11 +19,13 @@ public class HtmlContentController : ControllerBase
     public async Task<ContentResult> Render(
         [FromBody] IReadOnlyCollection<IFrameLine> frames,
         [FromQuery] RenderMode renderMode = RenderMode.Simple,
+        [FromQuery] bool preStyled = false,
         CancellationToken cancellationToken = default)
     {
         RenderOptions renderOptions = new RenderOptions
         {
             Mode = renderMode,
+            PreStyled = preStyled
         };
 
         return new ContentResult()

--- a/src/NetStackBeautifier.WebAPI/Controllers/HtmlController.cs
+++ b/src/NetStackBeautifier.WebAPI/Controllers/HtmlController.cs
@@ -16,11 +16,16 @@ public class HtmlController
     }
 
     [HttpPost]
-    public async Task<ContentResult> Render([FromBody] IReadOnlyCollection<IFrameLine> frames, [FromQuery] RenderMode renderMode = RenderMode.Simple, CancellationToken cancellationToken = default)
+    public async Task<ContentResult> Render(
+        [FromBody] IReadOnlyCollection<IFrameLine> frames,
+        [FromQuery] RenderMode renderMode = RenderMode.Simple,
+        [FromQuery] bool preStyled = false,
+        CancellationToken cancellationToken = default)
     {
         RenderOptions renderOptions = new RenderOptions
         {
             Mode = renderMode,
+            PreStyled = preStyled
         };
         return new ContentResult()
         {


### PR DESCRIPTION
What do you think about this? Trying to decouple the html renderer from the presentation layer a bit. Sends over classnames by default unless given a preStyled param in which case the styles/colors are baked inline into the elements. 