### PR TITLE
Supports display line number for debugging callstack

### DIFF
--- a/src/NetStackBeautifier.Services.Tests/AIProfilerStackManagedMethodMatcherTests.cs
+++ b/src/NetStackBeautifier.Services.Tests/AIProfilerStackManagedMethodMatcherTests.cs
@@ -1,0 +1,35 @@
+using NetStackBeautifier.Core;
+using NetStackBeautifier.Services.StackBeautifiers;
+using Xunit;
+
+namespace NetStackBeautifier.Services.Tests;
+
+public class AIProfilerStackManagedMethodMatcherTests
+{
+    [Theory]
+    [InlineData(@"System.Web.Http.Controllers.ReflectedHttpActionDescriptor+ActionExecutor.Execute(class System.Object,class System.Object[])", true)]
+    [InlineData(@"Microsoft.Azure.ChangeAnalysis.AzureResourceManager.AzureResourceManagerClient.SendAuthenticatedRequestWithRetryAsync.AnonymousMethod__0(System.Net.Http.StreamContent streamContent, System.TimeSpan retryTimeout) Line 45 C#", true)]
+    [InlineData(@"System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&)", true)]
+    [InlineData(@"System.Web.Http.Controllers.ApiControllerActionInvoker+<InvokeActionAsyncCore>d__1.MoveNext()", true)]
+
+    [InlineData(@"SlowAllocateString", false)]
+    public void ShouldMatchBasicCases(string input, bool expectMatch)
+    {
+        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher();
+        bool actual = target.TryCreate(input, string.Empty, FrameClassNameFactory.Instance, out _);
+        Assert.Equal(expectMatch, actual);
+    }
+
+    [Fact]
+    public void AssemblyInfoIsPassedThrough()
+    {
+        string input = @"System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&)";
+        string assemblyInfo = "HelloAssemblyInfo";
+        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher();
+        bool actual = target.TryCreate(input, assemblyInfo, FrameClassNameFactory.Instance, out FrameItem? output);
+        Assert.True(actual);
+        Assert.NotNull(output);
+
+        Assert.Equal(assemblyInfo, output?.AssemblySignature);
+    }
+}

--- a/src/NetStackBeautifier.Services.Tests/AIProfilerStackManagedMethodMatcherTests.cs
+++ b/src/NetStackBeautifier.Services.Tests/AIProfilerStackManagedMethodMatcherTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using NetStackBeautifier.Core;
 using NetStackBeautifier.Services.StackBeautifiers;
 using Xunit;
@@ -15,7 +16,7 @@ public class AIProfilerStackManagedMethodMatcherTests
     [InlineData(@"SlowAllocateString", false)]
     public void ShouldMatchBasicCases(string input, bool expectMatch)
     {
-        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher();
+        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher(new AIProfilerStackFileInfoMatcher(Enumerable.Empty<ILineInfoMatcher>()));
         bool actual = target.TryCreate(input, string.Empty, FrameClassNameFactory.Instance, out _);
         Assert.Equal(expectMatch, actual);
     }
@@ -25,7 +26,7 @@ public class AIProfilerStackManagedMethodMatcherTests
     {
         string input = @"System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[System.__Canon].Start(!!0&)";
         string assemblyInfo = "HelloAssemblyInfo";
-        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher();
+        AIProfilerStackManagedSignatureMatcher target = new AIProfilerStackManagedSignatureMatcher(new AIProfilerStackFileInfoMatcher(Enumerable.Empty<ILineInfoMatcher>()));
         bool actual = target.TryCreate(input, assemblyInfo, FrameClassNameFactory.Instance, out FrameItem? output);
         Assert.True(actual);
         Assert.NotNull(output);

--- a/src/NetStackBeautifier.Services.Tests/AIProfilerTraceBeautifierMatchTests.cs
+++ b/src/NetStackBeautifier.Services.Tests/AIProfilerTraceBeautifierMatchTests.cs
@@ -20,7 +20,7 @@ public class AIProfilerTraceBeautifierMatchTests
             Enumerable.Empty<ILineBeautifier<AIProfilerStackBeautifier>>(),
             Enumerable.Empty<IFrameFilter<AIProfilerStackBeautifier>>(),
             Enumerable.Empty<IPreFilter<AIProfilerStackBeautifier>>(),
-            new AIProfilerStackManagedSignatureMatcher(),
+            new AIProfilerStackManagedSignatureMatcher(new AIProfilerStackFileInfoMatcher(Enumerable.Empty<ILineInfoMatcher>())),
             FrameClassNameFactory.Instance);
 
         foreach (string testFilePath in Directory.EnumerateFiles(".", inputFilePattern))

--- a/src/NetStackBeautifier.Services.Tests/AIProfilerTraceBeautifierMatchTests.cs
+++ b/src/NetStackBeautifier.Services.Tests/AIProfilerTraceBeautifierMatchTests.cs
@@ -20,6 +20,7 @@ public class AIProfilerTraceBeautifierMatchTests
             Enumerable.Empty<ILineBeautifier<AIProfilerStackBeautifier>>(),
             Enumerable.Empty<IFrameFilter<AIProfilerStackBeautifier>>(),
             Enumerable.Empty<IPreFilter<AIProfilerStackBeautifier>>(),
+            new AIProfilerStackManagedSignatureMatcher(),
             FrameClassNameFactory.Instance);
 
         foreach (string testFilePath in Directory.EnumerateFiles(".", inputFilePattern))

--- a/src/NetStackBeautifier.Services/Filters/NoiseFilter.cs
+++ b/src/NetStackBeautifier.Services/Filters/NoiseFilter.cs
@@ -54,6 +54,21 @@ internal class NoiseFilter<T> : IFrameFilter<T>
             return true;
         }
 
+        if (rawText.Value.Trim().Equals("[Resuming Async Method]", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (rawText.Value.Trim().Equals("[External Code]", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (rawText.Value.Trim().Equals("[Async Call Stack]", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/NetStackBeautifier.Services/Parsers/AIProfilerStackFileInfoMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/AIProfilerStackFileInfoMatcher.cs
@@ -1,0 +1,36 @@
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Aggregated service to create a FrameFileInfo object from content.
+/// </summary>
+public class AIProfilerStackFileInfoMatcher
+{
+    private readonly IEnumerable<ILineInfoMatcher> _matchers;
+
+    public AIProfilerStackFileInfoMatcher(IEnumerable<ILineInfoMatcher> matchers)
+    {
+        _matchers = matchers ?? throw new ArgumentNullException(nameof(matchers));
+    }
+
+    public bool TryCreate(string content, out FrameFileInfo? frameFileInfo)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            throw new ArgumentException($"'{nameof(content)}' cannot be null or empty.", nameof(content));
+        }
+
+        foreach (ILineInfoMatcher matcher in _matchers)
+        {
+            if (matcher.TryCreate(content, out FrameFileInfo? newInstance))
+            {
+                frameFileInfo = newInstance;
+                return true;
+            }
+        }
+
+        frameFileInfo = null;
+        return false;
+    }
+}

--- a/src/NetStackBeautifier.Services/Parsers/AIProfilerStackManagedSignatureMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/AIProfilerStackManagedSignatureMatcher.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Builds a FrameItem from a line of managed code.
+/// </summary>
+public class AIProfilerStackManagedSignatureMatcher
+{
+    // Matches managed code signature. For example:
+    // Microsoft.Azure.ChangeAnalysis.Authorization.AzureResourceManagerAuthorization.AcquireAuthorizationTokenAsync(System.Uri authority, bool forceRefreshToken, System.Threading.CancellationToken cancellationToken) Line 42 C#
+    // Group 1: Full class name
+    // Group 2: Method Name
+    // Group 3: Parameter list
+    // Group 4*: File Path Info
+    // Group 5*: Line Number
+    // Group 6*: Language
+    // 
+    // Group 4 and 5 are optional
+    private const string MatchExpression = @"^(.*)\.(.*)?\((.*)\)(?:\s*(.*?)\s*([\d]+)\s*(.*))?$";
+    private readonly Regex _matcher = new(MatchExpression, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Creates a FrameItem when matches. Returns true. Otherwise, output FrameItem be null and returns false.
+    /// </summary>
+    public bool TryCreate(
+        string content,
+        string assemblyInfo,
+        FrameClassNameFactory frameClassNameFactory,
+        out FrameItem? newFrameItem)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            throw new ArgumentException($"'{nameof(content)}' cannot be null or empty.", nameof(content));
+        }
+        newFrameItem = null;
+        Match match = _matcher.Match(content);
+
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        string parameterList = match.Groups[3].Value;
+        string[] tokens = parameterList.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        List<FrameParameter> methodParameters = new List<FrameParameter>();
+        foreach (string parameterDescriptor in tokens)
+        {
+            string? parameterType = parameterDescriptor.Split(' ', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+            if (!string.IsNullOrEmpty(parameterType))
+            {
+                methodParameters.Add(new FrameParameter(parameterType.Trim(), string.Empty));
+            }
+        }
+
+        FrameFileInfo? frameFileInfo = match.Groups[5].Success ? new FrameFileInfo(match.Groups[4].Value, int.Parse(match.Groups[5].Value)) : null;
+        newFrameItem = new FrameItem()
+        {
+            FullClass = frameClassNameFactory.FromString(match.Groups[1].Value),
+            Method = new FrameMethod()
+            {
+                Name = match.Groups[2].Value,
+                Parameters = methodParameters,
+            },
+            FileInfo = frameFileInfo,
+            AssemblySignature = assemblyInfo,
+        };
+
+        return true;
+    }
+}

--- a/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/ILineInfoMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/ILineInfoMatcher.cs
@@ -1,0 +1,11 @@
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Services that matches line info from a stack frame
+/// </summary>
+public interface ILineInfoMatcher
+{
+    bool TryCreate(string input, out FrameFileInfo? fileInfo);
+}

--- a/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/LineNumberLangMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/LineNumberLangMatcher.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Matches line info like this: Line 42 C#
+/// </summary>
+internal class LineNumberLangMatcher : RegexLineInfoMatcherBase
+{
+    // Matches anything starts with 'Line' like:  Line 42 C#
+    // Group 1: Line number ==> 42
+    private const string MatchExp = @"^\s*Line ([\d]+)";
+
+    public LineNumberLangMatcher() : base(MatchExp)
+    {
+    }
+
+    protected override FrameFileInfo CreateOnSuccessMatch(Match match)
+    {
+        return new FrameFileInfo(string.Empty, int.Parse(match.Groups[1].Value));
+    }
+}

--- a/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/PathColonLineNumberMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/PathColonLineNumberMatcher.cs
@@ -1,0 +1,27 @@
+using System.Text.RegularExpressions;
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Matches line info in parentheses, example: (d:\Repos\NetStackBeautifier\src\NetStackBeautifier.Services\Parsers\SimpleExceptionStackBeautifier.cs:59)
+/// </summary>
+internal class PathColonLineNumberMatcher : RegexLineInfoMatcherBase
+{
+    // Matches line info in parentheses.
+    // For example: (d:\Repos\NetStackBeautifier\src\NetStackBeautifier.Services\Parsers\SimpleExceptionStackBeautifier.cs:59)
+    // Group 1: FilePath  ==> d:\Repos\NetStackBeautifier\src\NetStackBeautifier.Services\Parsers\SimpleExceptionStackBeautifier.cs
+    // Group 2: Line Number  ==> 59
+    private const string Regex = @"\((.*):\s*([\d]+)\)";
+    public PathColonLineNumberMatcher() : base(Regex)
+    {
+    }
+
+    protected override FrameFileInfo CreateOnSuccessMatch(Match match)
+    {
+        return new FrameFileInfo(
+            FilePath: match.Groups[1].Value,
+            LineNumber: match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0
+        );
+    }
+}

--- a/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/PlainExceptionLineInfoMatcher.cs
+++ b/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/PlainExceptionLineInfoMatcher.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Match line info like this:  in D:\Demo\LearnThrow\Program.cs:line 49
+/// Starts with `in `, followed by file and line number.
+/// </summary>
+internal class PlainExceptionLineInfoMatcher : RegexLineInfoMatcherBase
+{
+    // Matches:  in D:\Demo\LearnThrow\Program.cs:line 49
+    // Group 1: File Path ==> D:\Demo\LearnThrow\Program.cs
+    // Group 2: Line number ==> 49
+    private const string MatchExp = @"^\s*in\s+(.*):.*\s+([\d]+)$";
+    public PlainExceptionLineInfoMatcher() : base(MatchExp)
+    {
+    }
+
+    protected override FrameFileInfo CreateOnSuccessMatch(Match match) =>
+        new FrameFileInfo(
+            FilePath: match.Groups[1].Success ? match.Groups[1].Value : string.Empty,
+            LineNumber: match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0
+        );
+}

--- a/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/RegexLineInfoMatcherBase.cs
+++ b/src/NetStackBeautifier.Services/Parsers/LineInfoMatchers/RegexLineInfoMatcherBase.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using NetStackBeautifier.Core;
+
+namespace NetStackBeautifier.Services.StackBeautifiers;
+
+/// <summary>
+/// Base class for line info regex matcher
+/// </summary>
+internal abstract class RegexLineInfoMatcherBase : ILineInfoMatcher
+{
+    private readonly string _matchExp;
+    private readonly Regex _matcher;
+
+    public RegexLineInfoMatcherBase(string regexExpression)
+    {
+        if (string.IsNullOrWhiteSpace(regexExpression))
+        {
+            throw new ArgumentException($"'{nameof(regexExpression)}' cannot be null or whitespace.", nameof(regexExpression));
+        }
+
+        _matchExp = regexExpression;
+        _matcher = new Regex(_matchExp, RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
+    }
+
+    public bool TryCreate(string input, out FrameFileInfo? fileInfo)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new ArgumentException($"'{nameof(input)}' cannot be null or whitespace.", nameof(input));
+        }
+
+        Match match = _matcher.Match(input);
+        if (!match.Success)
+        {
+            fileInfo = null;
+            return false;
+        }
+
+        fileInfo = CreateOnSuccessMatch(match);
+        return true;
+    }
+
+    protected abstract FrameFileInfo CreateOnSuccessMatch(Match match);
+}

--- a/src/NetStackBeautifier.Services/Register.cs
+++ b/src/NetStackBeautifier.Services/Register.cs
@@ -14,6 +14,7 @@ namespace NetStackBeautifier.Services
             // Register fundamentals
             services.TryAddScoped<LineBreaker>();
             services.TryAddScoped<AzureProfilerStackLineCreator>();
+            services.TryAddScoped<AIProfilerStackManagedSignatureMatcher>();
             services.TryAddSingleton<FrameClassNameFactory>(p => FrameClassNameFactory.Instance);
             services.TryAddScoped<IBeautifierService, BeautifierService>();
 

--- a/src/NetStackBeautifier.Services/Register.cs
+++ b/src/NetStackBeautifier.Services/Register.cs
@@ -13,10 +13,18 @@ namespace NetStackBeautifier.Services
         {
             // Register fundamentals
             services.TryAddScoped<LineBreaker>();
+            services.TryAddScoped<IBeautifierService, BeautifierService>();
+
+            // Register parser dependencies
             services.TryAddScoped<AzureProfilerStackLineCreator>();
             services.TryAddScoped<AIProfilerStackManagedSignatureMatcher>();
             services.TryAddSingleton<FrameClassNameFactory>(p => FrameClassNameFactory.Instance);
-            services.TryAddScoped<IBeautifierService, BeautifierService>();
+
+            services.TryAddScoped<AIProfilerStackFileInfoMatcher>();
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<ILineInfoMatcher, PlainExceptionLineInfoMatcher>());
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<ILineInfoMatcher, PathColonLineNumberMatcher>());
+            services.TryAddEnumerable(ServiceDescriptor.Scoped<ILineInfoMatcher, LineNumberLangMatcher>());
+
 
             // Register Parsers
             services.TryAddEnumerable(ServiceDescriptor.Scoped<IBeautifier, AIProfilerStackBeautifier>());


### PR DESCRIPTION
Example:

```cpp
[Async] Microsoft.Azure.TestService.dll!Microsoft.Azure.TestService.Program.Main(string[] args) Line 61	C#
```
The line number and the languages wasn't handled.